### PR TITLE
Pypi api version check

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,11 +4,11 @@ beautifulsoup4
 black
 boto3
 boto3-stubs[lambda,s3]
-fastapi
+fastapi<0.100.0
 mangum
 orjson
 passlib
-pydantic
+pydantic<2.0.0
 python-multipart
 requests
 uvicorn

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ lambda_name = "serverless-pypi"
 # Versions should comply with PEP440.  For a discussion on single-sourcing
 # the version across setup.py and the project code, see
 # https://packaging.python.org/en/latest/single_source_version.html
-lambda_version = "0.0.6"
+lambda_version = "0.0.7-tra.1"
 
 lambda_description = "An AWS Lambda implementation for the PyPI protocols"
 

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,11 @@ lambda_install_requires = [
     "aws-error-utils",
     "backoff",
     "beautifulsoup4",
-    "fastapi",
+    "fastapi<0.100.0",
     "mangum",
     "orjson",
     "passlib",
-    "pydantic",
+    "pydantic<2.0.0",
     "python-multipart",
     "requests",
 ]

--- a/src/lambda_function/function.py
+++ b/src/lambda_function/function.py
@@ -140,8 +140,8 @@ class PyPIMeta(BaseModel, json_dumps=orjson_dumps, json_loads=orjson.loads):
 
     @validator("api_version")
     def api_version_validator(cls, value: str) -> str:
-        if value != "1.0":
-            raise ValueError(f"Received an unknown 'api-version': {value}")
+        if value != "1.0" and value != "1.1":
+            raise ValueError(f"Received an unknown 'api-version': {value} {type(value)}")
         return value
 
     def html(self) -> str:

--- a/src/lambda_function/function.py
+++ b/src/lambda_function/function.py
@@ -713,7 +713,7 @@ async def get_project_list(
 @APP.post("/", status_code=status.HTTP_201_CREATED)
 async def upload_project_file(
     request: Request, user: AuthorizedUser = Depends(authorize_user)
-) -> Optional[Response]:
+):
     if not user.upload:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     form = await request.form()


### PR DESCRIPTION
As per [PEP 700](https://peps.python.org/pep-0700/), the `api-version` of pypi.org/simple has been bumped up to `1.1`.

This PR updates our code so that it doesn't break when the `api-version` is `1.1`.

**Additional Changes**

* removed return types for `upload_project_file()` as it throws the following error on updated dependencies:
    ```
    fastapi.exceptions.FastAPIError: Invalid args for response field! Hint: check that typing.Optional[starlette.responses.Response] is a valid Pydantic field type. If you are using a return type annotation that is not a valid Pydantic field (e.g. Union[Response, dict, None]) you can disable generating the response model from the type annotation with the path operation decorator parameter response_model=None. Read more: https://fastapi.tiangolo.com/tutorial/response-model/
    ```
* update & limit the dependency versions (e.g. pydantic using <2.0)
* bump version to `0.0.7-tra.1` (next pre-release after `0.0.6`, in our fork)