### PR TITLE
update version to use pyproject-compatible alpha suffix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ lambda_name = "serverless-pypi"
 # Versions should comply with PEP440.  For a discussion on single-sourcing
 # the version across setup.py and the project code, see
 # https://packaging.python.org/en/latest/single_source_version.html
-lambda_version = "0.0.7-tra.1"
+lambda_version = "0.0.7-alpha"
 
 lambda_description = "An AWS Lambda implementation for the PyPI protocols"
 


### PR DESCRIPTION
Previously, for forks we use the version format `x.y.z-tra.n` where `x.y.z` is 1 patch above the source repo's version, and n is our own version number.

However this seems to not be compatible with the new setuptools; it has the following error:

```
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      Traceback (most recent call last):
        File "/home/gede/work/tra/private-pypi/.direnv/python-3.9.11/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/gede/work/tra/private-pypi/.direnv/python-3.9.11/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/gede/work/tra/private-pypi/.direnv/python-3.9.11/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 366, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 480, in run_setup
          super(_BuildMetaLegacyBackend, self).run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 60, in <module>
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 147, in setup
          _setup_distribution = dist = klass(attrs)
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 314, in __init__
          self.metadata.version = self._normalize_version(self.metadata.version)
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 350, in _normalize_version
          normalized = str(Version(version))
        File "/tmp/pip-build-env-hqj39v3v/overlay/lib/python3.9/site-packages/setuptools/_vendor/packaging/version.py", line 198, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      setuptools.extern.packaging.version.InvalidVersion: Invalid version: '0.0.7-tra.1'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

For now we will re-version this to `0.0.7-alpha`.

### Misc

We might want to check other forks that we have e.g. https://github.com/tra-sg/stairstep